### PR TITLE
Update Terraform versions and set TFENV_AUTO_INSTALL=false

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
 	git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin \
 	&& \
-	tfenv install 0.11.8 && tfenv install 0.12.17
+	tfenv install 0.12.31 && tfenv install 0.14.11
 
+ENV TFENV_AUTO_INSTALL=false
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Updates Terraform versions installed to 0.12.31 and 0.14.11 to fix potential provider issues caused by a Hashicorp GPG key leak.

https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512
https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570

Also sets TFENV_AUTO_INSTALL=false so that by default only versions of Terraform included in this image are used i.e. other versions are not downloaded and installed.