### PR TITLE
Install Terraform 1.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+### What is the context of this PR?
+Describe what you have changed and why, link to other PRs or Issues as appropriate.
+
+### How to review 
+Describe the steps required to test the changes (include screenshots if appropriate).

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 	git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin \
 	&& \
-	tfenv install 0.12.31 && tfenv install 0.14.11
+	tfenv install 0.12.31 && tfenv install 0.14.11 && tfenv install 1.0.0
 
 ENV TFENV_AUTO_INSTALL=false
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
### What is the context of this PR?
Installs version 1.0.0 of Terraform to be used by the new changes for Cloud Run.
Once the old infrastructure is no longer needed, `cloud-sdk` and `kubectl` can be removed.

### How to review 
Review as part of the usage in https://github.com/ONSdigital/eq-terraform-gcp/pull/59 