### PR TITLE
Update Terraform to 1.7.3 and remove Terraform 1.0.0 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 	git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin \
 	&& \
-	tfenv install 1.0.0 && tfenv install 1.3.7
+	tfenv install 1.7.3
 
 ENV TFENV_AUTO_INSTALL=false
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 	git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin \
 	&& \
-	tfenv install 1.7.3
+	tfenv install 1.3.7 && tfenv install 1.7.3
 
 ENV TFENV_AUTO_INSTALL=false
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
### What is the context of this PR?
Removes redundant Terraform 1.0.0 version, adds 1.7.3 while keeping 1.3.7 until we fully migrate.

### How to review
Many different ways, for example, push an image of this branch to your own image registry (remember about updating user roles to make images in your artifact registry viewable) and update pipelines.yaml of your staging so it uses your resource from your image registry, something like (you need to do this everywhere image_registry and deploy_image_version are called: 
```yaml
      vars:
        image_registry: europe-west2-docker.pkg.dev/pete-staging-02-01-2024/docker-images
        deploy_image_version: 1.7.3-test
```
Except consumer function which uses its own deploy image that doesnt use terraform.
