### PR TITLE
Update Dockerfile base image and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update --no-cache add curl
 
 FROM alpine:3.19 AS builder_tfenv
 
-# Install tfenv
+# Install tfenv and terraform
 RUN apk add --no-cache bash git curl && \
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin && \
@@ -23,6 +23,7 @@ RUN apk add --no-cache python3 bash jq
 COPY --from=builder_cloud_sdk google-cloud-sdk/lib /google-cloud-sdk/lib
 COPY --from=builder_cloud_sdk google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
 COPY --from=builder_tfenv /usr/local/bin/tfenv /usr/local/bin/tfenv
+COPY --from=builder_tfenv /usr/local/bin/terraform /usr/local/bin/terraform
 
 # Update gcloud config
 RUN gcloud config set core/disable_usage_reporting true && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder_cloud_sdk
 FROM alpine:3.19 AS builder_tfenv
 
 # Install tfenv
-RUN apk add --no-cache bash git curl && \
+RUN apk add --no-cache bash git && \
     git clone --depth=1 https://github.com/tfutils/tfenv.git /tfenv
 
 FROM alpine:3.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache bash git && \
     git clone --depth=1 https://github.com/tfutils/tfenv.git /tfenv
 
 FROM alpine:3.19
+
 # Add gcloud and tfenv to the path
 ENV PATH /google-cloud-sdk/bin:$PATH
 ENV PATH /tfenv/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder_cloud_sdk
 
 # Install gcloud auth plugin, kubectl and helm
 RUN apk --update --no-cache add curl
+
+FROM alpine:3.19 AS builder_tfenv
+
+# Install tfenv
+RUN apk add --no-cache bash git curl && \
+    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
+	ln -s /root/.tfenv/bin/* /usr/local/bin && \
+	tfenv install 1.7.3
+
 
 FROM alpine:3.19
 # Add gcloud to the path
 ENV PATH /google-cloud-sdk/bin:$PATH
 
 # Install dependencies
-RUN apk add --no-cache python3 bash jq git curl && \
-    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
-	ln -s /root/.tfenv/bin/* /usr/local/bin && \
-	tfenv install 1.7.3
+RUN apk add --no-cache python3 bash jq
 
 # Copy binaries from the builder
-COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib
-COPY --from=builder google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
+COPY --from=builder_cloud_sdk google-cloud-sdk/lib /google-cloud-sdk/lib
+COPY --from=builder_cloud_sdk google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
+COPY --from=builder_tfenv /usr/local/bin/tfenv /usr/local/bin/tfenv
 
 # Update gcloud config
 RUN gcloud config set core/disable_usage_reporting true && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 ENV PATH /tfenv/bin:$PATH
 
 # Install dependencies
-RUN apk add --no-cache python3 bash jq curl
+RUN apk add --no-cache python3 bash jq curl git
 
 # Copy binaries from the builders
 COPY --from=builder_cloud_sdk google-cloud-sdk/lib /google-cloud-sdk/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,26 @@
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine AS builder
 
-RUN apt-get update && \
-	apt-get -y install unzip kubectl \
-	&& \
-	git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
-	ln -s /root/.tfenv/bin/* /usr/local/bin \
-	&& \
-	tfenv install 1.3.7 && tfenv install 1.7.3
+# Install gcloud auth plugin, kubectl and helm
+RUN apk --update --no-cache add curl
 
-ENV TFENV_AUTO_INSTALL=false
-ENTRYPOINT ["/bin/bash"]
+FROM alpine:3.19
+# Add gcloud to the path
+ENV PATH /google-cloud-sdk/bin:$PATH
+
+# Install dependencies
+RUN apk add --no-cache python3 bash jq git curl && \
+    git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
+	ln -s /root/.tfenv/bin/* /usr/local/bin && \
+	tfenv install 1.7.3
+
+# Copy binaries from the builder
+COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib
+COPY --from=builder google-cloud-sdk/bin/gcloud google-cloud-sdk/bin/gcloud
+
+# Update gcloud config
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image
+
+# Set the default configuration directory
+VOLUME ["/root/.config"]


### PR DESCRIPTION
### What is the context of this PR?
This updates the base image distro to Alpine and installs only essential dependencies in order to resolve the existing and minimise new vulnerabilities reported in image scanning. The amount of High and Critical severity vulnerabilities is greatly reduced now. Old 1.3.7 Terraform is also removed as not used anymore. 

### How to review
Make sure that whenever infrastructure deploy image is used in pipelines it still works. In Alpine different package management tool is used (apk instead of apt) so that could lead to some potential issues if anywhere in the ci scripts we reference the Debian specific tools.
Check if removing 1.3.7 Terraform didn't break anything, if any script still expects this version of TF.